### PR TITLE
Keymap for DragonRise controllers

### DIFF
--- a/keymaps/joystick.DragonRise_homemade_joysticks.xml
+++ b/keymaps/joystick.DragonRise_homemade_joysticks.xml
@@ -1,0 +1,19 @@
+<keymap>
+	<global>
+		<joystick name="DragonRise Inc.   Generic   USB  Joystick  ">
+			<button id="9">Playlist</button>
+			<button id="2">Back</button>
+			<button id="1">Select</button>
+			<button id="5">ContextMenu</button>
+			<button id="8">PageUp</button>
+			<button id="4">PageDown</button>
+			<button id="11">SkipPrevious</button>
+			<button id="12">SkipNext</button>
+			<button id="10">Play</button>
+			<axis id="1" limit="-1">Left</axis>
+			<axis id="1" limit="+1">Right</axis>
+			<axis id="2" limit="-1">Up</axis>
+			<axis id="2" limit="+1">Down</axis>
+		</joystick>
+	</global>
+</keymap>


### PR DESCRIPTION
Keymap for DragonRise USB controllers, very used on homemade joysticks for arcade cabinets:
http://i.ebayimg.com/images/g/xx0AAOSw8cNUSk1J/s-l1600.jpg